### PR TITLE
fix: make monthly pricing hidden before render when JS on

### DIFF
--- a/_includes/foot-scripts.html
+++ b/_includes/foot-scripts.html
@@ -1,0 +1,36 @@
+
+<script>
+  // Adds class of js to the html tag if JS is enabled
+  document.getElementsByTagName('html')[0].className += 'js';
+  // Adds class of svg to the html tag if svg is enabled
+  (function flagSVG() {
+      var ns = {'svg': 'http://www.w3.org/2000/svg'};
+      if(document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#BasicStructure", "1.1")) {document.getElementsByTagName('html')[0].className += ' svg';}
+  })();
+</script>
+<script src="/js/vendor/jquery-1.11.3.min.js?895323ed2f7258af4fae2c738c8aea49"></script>
+<script src="/js/build/app.min.js?5d657d3c4463fadae8390708cf910574"></script>
+
+  <script src="/js/vendor/segment.min.js"></script>
+  <script type="text/javascript">
+    analytics.load('rrZlYpGGcdrLvloIXwGTqX8ZAQNsB9A0');
+  </script>
+
+<script type="text/javascript">
+    analytics.identify(
+      '20200352-0c23-4d49-b6ce-c9db82605da5',
+      {
+        anonymousId: '20200352-0c23-4d49-b6ce-c9db82605da5'
+      },
+      {
+        integrations: {
+          'All': true,
+          'Intercom': false
+        }
+      }
+    );
+</script>
+
+<script type="text/javascript">
+  analytics.page();
+</script>

--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -1,39 +1,3 @@
 
-<script>
-  // Adds class of js to the html tag if JS is enabled
-  document.getElementsByTagName('html')[0].className += 'js';
-  // Adds class of svg to the html tag if svg is enabled
-  (function flagSVG() {
-      var ns = {'svg': 'http://www.w3.org/2000/svg'};
-      if(document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#BasicStructure", "1.1")) {document.getElementsByTagName('html')[0].className += ' svg';}
-  })();
-</script>
-<script src="/js/vendor/jquery-1.11.3.min.js?895323ed2f7258af4fae2c738c8aea49"></script>
-<script src="/js/build/app.min.js?5d657d3c4463fadae8390708cf910574"></script>
-
-  <script src="/js/vendor/segment.min.js"></script>
-  <script type="text/javascript">
-    analytics.load('rrZlYpGGcdrLvloIXwGTqX8ZAQNsB9A0');
-  </script>
-
-<script type="text/javascript">
-    analytics.identify(
-      '20200352-0c23-4d49-b6ce-c9db82605da5',
-      {
-        anonymousId: '20200352-0c23-4d49-b6ce-c9db82605da5'
-      },
-      {
-        integrations: {
-          'All': true,
-          'Intercom': false
-        }
-      }
-    );
-</script>
-
-<script type="text/javascript">
-  analytics.page();
-</script>
-
 </body>
 </html>

--- a/_layouts/features.html
+++ b/_layouts/features.html
@@ -41,4 +41,5 @@
 
 {% include footer.html %}
 
+{% include foot-scripts.html %}
 {% include foot.html %}

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -150,4 +150,5 @@
 
 {% include footer.html %}
 
+{% include foot-scripts.html %}
 {% include foot.html %}

--- a/_layouts/policies.html
+++ b/_layouts/policies.html
@@ -24,4 +24,5 @@
 
 {% include footer.html %}
 
+{% include foot-scripts.html %}
 {% include foot.html %}

--- a/_layouts/pricing.html
+++ b/_layouts/pricing.html
@@ -2,6 +2,11 @@
 
 {% include header.html %}
 
+<!-- For JS browsers, disable the monthly class by default -->
+<script>
+document.styleSheets[0].insertRule('.js-toggle__content--monthly {display:none}',0);
+</script>
+
 <main class="layout-stacked">
 
 <div class="backdrop-positive">
@@ -111,5 +116,11 @@
 </main>
 
 {% include footer.html %}
+
+{% include foot-scripts.html %}
+
+<script>
+document.styleSheets[0].insertRule('.js-toggle__content--monthly {display:block}',0);
+</script>
 
 {% include foot.html %}


### PR DESCRIPTION
- [x] Ready to merge
- [ ] Reviewed by @maban 
## What does it do?

When rendering the pricing page, the monthly section is visible by default, to support non-JS viewers. 
It's only hidden with an async script at the bottom, which finds the relevant elements and hides them. 

This creates an odd rendering order, which can be seen here: http://www.webpagetest.org/video/compare.php?tests=160617_4F_809ce4e8ef38e8ae152073ea920fe91c-r:1-c:0

This fix changes that to modify the actual _class_ the monthly rendering uses, making it visible or not. 
I haven't changed the toggle actions, as once loaded it doesn't really matter if you change the class or the elements.
