### PR TITLE
feat: update page metadata in the head to include Ruby

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,8 +5,8 @@
     <meta http-equiv="Content-Language" content="en-us">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>{% if page.title %}{{page.title}}{% else %}Snyk{% endif %}</title>
-    <meta name="description" content="{% if page.meta-description %}{{page.meta-description}}{% else %}So Now You Know{% endif %}">
+    <title>{% if page.title %}{{page.title}} | Snyk{% else %}Snyk{% endif %}</title>
+    <meta name="description" content="{% if page.meta-description %}{{page.meta-description}}{% else %}Fix known vulnerabilities in your Node.js and Ruby apps: apply upgrades and security patches, prevent adding vulnerable dependencies, and get alerted about new security issues.{% endif %}">
     {% unless jekyll.environment == "production" %}<base href="https://snyk.io/">{% endunless %}
     <link rel="icon" type="image/png" href="https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.png" sizes="194x194">
     <link rel="icon" type="image/png" href="https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/android-chrome.png" sizes="192x192">
@@ -20,8 +20,8 @@
     <meta name="twitter:card" content="summary">
     <meta name="twitter:image" property="og:image" content="https://res.cloudinary.com/snyk/image/upload/v1468845142/logo/snyk-avatar.png">
     <meta name="twitter:site" content="@snyksec">
-    <meta name="twitter:title" property="og:title" content="{% if page.title %}{{page.title}}{% else %}Snyk{% endif %}">
-    <meta name="twitter:description" property="og:description" content="{% if page.meta-description %}{{page.meta-description}}{% else %}So Now You Know{% endif %}">
+    <meta name="twitter:title" property="og:title" content="{% if page.title %}Snyk - {{page.title}}{% else %}Snyk{% endif %}">
+    <meta name="twitter:description" property="og:description" content="{% if page.meta-description %}{{page.meta-description}}{% else %}Fix known vulnerabilities in your Node.js and Ruby apps: apply upgrades and security patches, prevent adding vulnerable dependencies, and get alerted about new security issues.{% endif %}">
     <link rel="stylesheet" href="/style/build/all.min.css">
     <!--[if lt IE 9]>
     <script src="/js/vendor/html5shiv.js"></script>

--- a/github-integration.html
+++ b/github-integration.html
@@ -1,10 +1,8 @@
 ---
 layout: homepage
 
-meta-description: "Fix known node.js vulnerabilities: apply upgrades and security patches, prevent adding vulnerable dependencies, and get alerted about new security issues."
-
 # the page title
-title: "Fix and prevent known vulnerabilities in Node.js apps | Snyk"
+title: "Fix and prevent known vulnerabilities in Node.js and Ruby apps"
 
 # the main title (white)
 main-title: "Dependencies make your app vulnerable."

--- a/homepage.html
+++ b/homepage.html
@@ -1,10 +1,8 @@
 ---
 layout: homepage
 
-meta-description: "Fix known node.js vulnerabilities: apply upgrades and security patches, prevent adding vulnerable dependencies, and get alerted about new security issues."
-
 # the page title
-title: "Fix and prevent known vulnerabilities in Node.js apps | Snyk"
+title: "Fix and prevent known vulnerabilities in Node.js and Ruby apps"
 
 # the main title (white)
 main-title: "Snyk continuously finds and fixes vulnerabilities in your dependencies."

--- a/policies.html
+++ b/policies.html
@@ -1,5 +1,4 @@
 ---
 layout: policies
 title: "Policies"
-meta-description: "Find &amp; fix known vulnerabilities in Node.js dependencies."
 ---


### PR DESCRIPTION
- [X] ready for merge

#### What's this PR do?

Updates the page metadata to refer to Ruby support as well as Node.js

#### Where should the reviewer start?

Any page!

#### How should this be manually tested?

- View source and check that all metadata in the `<head>` looks good.
- Maybe check the og and twitter tags with:

https://developers.facebook.com/tools/debug/
https://cards-dev.twitter.com/validator

#### Any background context you want to provide?


#### What are the relevant tickets?


#### Where is this documented?


#### Screenshots

<img width="539" alt="screen shot 2016-11-10 at 11 53 45" src="https://cloud.githubusercontent.com/assets/813784/20175772/61a95f38-a73c-11e6-8b07-f37e36b06721.png">
<img width="527" alt="screen shot 2016-11-10 at 11 53 31" src="https://cloud.githubusercontent.com/assets/813784/20175773/61acfab2-a73c-11e6-9711-87ef288b245e.png">


#### Release Notes?


#### Questions

